### PR TITLE
Downshift prevents form submission on enter when defaultHighlightIndex is set

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,60 +1,118 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 54659,
-    "minified": 24147,
-    "gzipped": 6645
+    "bundled": 54514,
+    "minified": 24061,
+    "gzipped": 6629
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 53228,
-    "minified": 22997,
-    "gzipped": 6449
+    "bundled": 53083,
+    "minified": 22911,
+    "gzipped": 6431
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 65820,
-    "minified": 22384,
-    "gzipped": 7184
+    "bundled": 65883,
+    "minified": 22490,
+    "gzipped": 7209
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 78595,
-    "minified": 27641,
-    "gzipped": 8541
+    "bundled": 79204,
+    "minified": 27918,
+    "gzipped": 8640
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 70699,
-    "minified": 23678,
-    "gzipped": 7749
+    "bundled": 70762,
+    "minified": 23903,
+    "gzipped": 7824
   },
   "dist/downshift.umd.js": {
-    "bundled": 107995,
-    "minified": 36646,
-    "gzipped": 11302
+    "bundled": 108604,
+    "minified": 36906,
+    "gzipped": 11395
   },
   "dist/downshift.esm.js": {
-    "bundled": 54285,
-    "minified": 23856,
-    "gzipped": 6573,
+    "bundled": 54140,
+    "minified": 23770,
+    "gzipped": 6554,
     "treeshaked": {
       "rollup": {
         "code": 373,
         "import_statements": 296
       },
       "webpack": {
-        "code": 18020
+        "code": 17965
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 52836,
-    "minified": 22810,
-    "gzipped": 6360,
+    "bundled": 52729,
+    "minified": 22635,
+    "gzipped": 6359,
     "treeshaked": {
       "rollup": {
         "code": 355,
         "import_statements": 278
       },
       "webpack": {
-        "code": 18062
+        "code": 17920
       }
     }
+  },
+  "dist/@lewisl9029/downshift.cjs.js": {
+    "bundled": 54514,
+    "minified": 24061,
+    "gzipped": 6629
+  },
+  "preact/dist/@lewisl9029/downshift.cjs.js": {
+    "bundled": 53083,
+    "minified": 22911,
+    "gzipped": 6431
+  },
+  "preact/dist/@lewisl9029/downshift.umd.min.js": {
+    "bundled": 65893,
+    "minified": 22500,
+    "gzipped": 7219
+  },
+  "preact/dist/@lewisl9029/downshift.umd.js": {
+    "bundled": 79214,
+    "minified": 27928,
+    "gzipped": 8650
+  },
+  "dist/@lewisl9029/downshift.esm.js": {
+    "bundled": 54140,
+    "minified": 23770,
+    "gzipped": 6554,
+    "treeshaked": {
+      "rollup": {
+        "code": 373,
+        "import_statements": 296
+      },
+      "webpack": {
+        "code": 17965
+      }
+    }
+  },
+  "preact/dist/@lewisl9029/downshift.esm.js": {
+    "bundled": 52729,
+    "minified": 22635,
+    "gzipped": 6359,
+    "treeshaked": {
+      "rollup": {
+        "code": 355,
+        "import_statements": 278
+      },
+      "webpack": {
+        "code": 17920
+      }
+    }
+  },
+  "dist/@lewisl9029/downshift.umd.min.js": {
+    "bundled": 70772,
+    "minified": 23913,
+    "gzipped": 7834
+  },
+  "dist/@lewisl9029/downshift.umd.js": {
+    "bundled": 108614,
+    "minified": 36916,
+    "gzipped": 11404
   }
 }

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -385,6 +385,19 @@ test('enter on an input with an open menu does nothing without a highlightedInde
   expect(childrenSpy).not.toHaveBeenCalled()
 })
 
+test.only('enter on an input with an open menu with 0 items calls submit', () => {
+  const {enterOnInput, queryByTestId, submitSpy} = renderDownshift({
+    items: [],
+    props: {isOpen: true, defaultHighlightedIndex: 0},
+  })
+  submitSpy.mockClear()
+  // ENTER
+  enterOnInput()
+  fireEvent.keyUp(queryByTestId('input'), {key: 'Enter'})
+  // onSubmit is called on form
+  expect(submitSpy).toHaveBeenCalledWith([])
+})
+
 test('enter on an input with an open menu and a highlightedIndex selects that item', () => {
   const onChange = jest.fn()
   const isOpen = true
@@ -643,7 +656,9 @@ function setup({items = colors} = {}) {
     ({isOpen, getInputProps, getToggleButtonProps, getItemProps}) => (
       <div>
         <input {...getInputProps({'data-testid': 'input'})} />
-        <button {...getToggleButtonProps({'data-testid': 'button'})} />
+        <button
+          {...getToggleButtonProps({type: 'button', 'data-testid': 'button'})}
+        />
         {isOpen && (
           <div>
             {items.map((item, index) => (
@@ -671,11 +686,17 @@ function setup({items = colors} = {}) {
 
 function renderDownshift({items, props} = {}) {
   const {Component, childrenSpy} = setup({items})
-  const utils = render(<Component {...props} />)
+  const submitSpy = jest.fn(event => event.preventDefault())
+  const utils = render(
+    <form onSubmit={submitSpy}>
+      <Component {...props} />
+    </form>,
+  )
   const input = utils.queryByTestId('input')
   return {
     Component,
     childrenSpy,
+    submitSpy,
     ...utils,
     input,
     button: utils.queryByTestId('button'),

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -595,7 +595,7 @@ class Downshift extends Component {
 
     Enter(event) {
       const {isOpen, highlightedIndex} = this.getState()
-      if (isOpen && highlightedIndex != null) {
+      if (isOpen && highlightedIndex != null && this.items[highlightedIndex]) {
         event.preventDefault()
         const item = this.items[highlightedIndex]
         const itemNode = this.getItemNodeFromIndex(highlightedIndex)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

`defaultHighlightIndex={0}` is useful for allowing users to quickly select the first suggestion in a typeahead just by pressing enter. However, we found that it has an unfortunate side-effect of preventing form submission on enter when there are no items in the suggestions list (i.e. when the user is trying to enter something that's not part of the suggestions list).

Here's a slightly modified version of the typeahead sandbox that changes the outer div to a form with a submit handler to help demonstrate the issue: 

https://codesandbox.io/s/downshift-examples-xgk4r?fontsize=14

1. First try removing `defaultHighlightedIndex={0}` and typing in 123 (or anything else that causes the suggestions list to become empty) and then pressing enter. You'll see the "not-submitted" text at the top of the page turn into "submitted", which is triggered by the custom onSubmit handler on the form.
2. Then try adding `defaultHighlightedIndex={0}` back in and doing the same. You'll see that not-submitted remains unchanged, meaning the onSubmit was never called.

<!-- Why are these changes necessary? -->

**Why**:

This happens because the enter key handling for downshift will call `event.preventDefault()` to prevent form submission behavior and set the selected item even if the item at the highlighted index doesn't exist: https://github.com/downshift-js/downshift/blob/master/src/downshift.js#L599

<!-- How were these changes implemented? -->

**How**:

This PR simply adds an additional check to ensure the item at the highlighted index actually exists before preventing default and trying to change selection to it on enter.

Here's a version of the sandbox using a fork of downshift with the fix here applied: https://codesandbox.io/s/downshift-examples-1r460?fontsize=14

**Additional Considerations**:

I also just noticed a test that seems to be incompatible with the behavior changed implemented in this PR: https://github.com/downshift-js/downshift/blob/master/src/__tests__/downshift.get-input-props.js#L537

And I'm not sure how to reconcile the two seemingly conflicting use cases. Would love to hear more thoughts/ideas on this.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
N/A
- [ ] Tests
I tried to add a test for this but couldn't get it to pass (the onSubmit handler on the form never ends up getting called). Would love to get some 👀 on it to see if I'm doing something wrong or if there's another way to test this.
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
